### PR TITLE
S3 Bucket Bulk Delete

### DIFF
--- a/aws_nuker.rb
+++ b/aws_nuker.rb
@@ -12,6 +12,8 @@ class AWSNuker
 
   # Public methods
   def run
+    puts "#{"="*20}DRY RUN STARTED" if @options[:dry_run]
+
     case @options[:service]
     when "ec2"
       ec2_termination

--- a/aws_nuker.rb
+++ b/aws_nuker.rb
@@ -81,7 +81,7 @@ class AWSNuker
         resp = s3.delete_bucket({ bucket: bucket.name })
       rescue Aws::S3::Errors::BucketNotEmpty
         puts "FAILURE: Bucket '#{bucket.name}' is not empty. Setting a lifecycle policy to destroy all objects inside the bucket by tomorrow."
-        puts "Please run the script again tomorrow."
+        puts "\tPlease run the script again tomorrow."
         resp = s3.put_bucket_lifecycle_configuration({
           bucket: bucket.name, 
           lifecycle_configuration: {
@@ -106,6 +106,10 @@ class AWSNuker
             ], 
           },
         })
+      rescue Aws::S3::Errors::ServiceError => e
+        puts "ERROR: #{e}"
+        puts "\tAttempting to delete bucket '#{bucket.name}' errored."
+        puts "\tTry deleting it manually."
       else
         puts "SUCCESS: Bucket '#{bucket.name}' got deleted successfully."
       end

--- a/aws_nuker.rb
+++ b/aws_nuker.rb
@@ -15,6 +15,8 @@ class AWSNuker
     case @options[:service]
     when "ec2"
       ec2_termination
+    when "s3"
+      s3_termination
     else
       raise ArgumentError.new("#{@options[:service]} is not a supported service.")
     end
@@ -39,15 +41,7 @@ class AWSNuker
     end
 
     # exit here if desired
-    if @options[:dry_run]
-      puts "#{"="*20}DRY RUN ENDED"
-      exit 0
-    end
-    puts "Are you sure that you want to terminate all instances above? (YES/NO)"
-    if gets.chomp.upcase != 'YES'
-      puts "Exiting..."
-      exit 0
-    end
+    early_exit('instance')
 
     # Turn off instance termination protection if enabled
     protected_instances = instances.filter do |instance|
@@ -65,6 +59,70 @@ class AWSNuker
       instance_ids: instances.map(&:instance_id)
     })
     puts "\nAll done!"
+  end
+
+  private def s3_termination
+    # show what will be deleted
+    s3 = Aws::S3::Client.new(profile: @options[:profile], region: @options[:region])
+    resp = s3.list_buckets
+    puts "* The following buckets will be deleted =>"
+    buckets = resp.buckets
+    buckets.each do |bucket|
+      puts "#{bucket.name}"
+    end
+
+    # exit here if desired
+    early_exit('bucket')
+
+    buckets.each do |bucket|
+      begin
+        resp = s3.delete_bucket({ bucket: bucket.name })
+      rescue Aws::S3::Errors::BucketNotEmpty
+        puts "FAILURE: Bucket '#{bucket.name}' is not empty. Setting a lifecycle policy to destroy all objects inside the bucket by tomorrow."
+        puts "Please run the script again tomorrow."
+        resp = s3.put_bucket_lifecycle_configuration({
+          bucket: bucket.name, 
+          lifecycle_configuration: {
+            rules: [
+              {
+                expiration: {
+                  days: 1, 
+                },
+                prefix: nil,
+                filter: {
+                  prefix: "", 
+                },
+                id: "DeleteAll", 
+                status: "Enabled",
+                noncurrent_version_expiration: {
+                  noncurrent_days: 1,
+                },
+                abort_incomplete_multipart_upload: {
+                  days_after_initiation: 1,
+                },
+              }, 
+            ], 
+          },
+        })
+      else
+        puts "SUCCESS: Bucket '#{bucket.name}' got deleted successfully."
+      end
+    end
+  end
+
+  private def early_exit(service_obj)
+    puts
+    service_name = service_obj
+    # exit here if desired
+    if @options[:dry_run]
+      puts "#{"="*20}DRY RUN ENDED"
+      exit 0
+    end
+    puts "Are you sure that you want to terminate/delete all #{service_name}s above? (YES/NO)"
+    if gets.chomp.upcase != 'YES'
+      puts "Exiting..."
+      exit 0
+    end
   end
 
   private def verify_args


### PR DESCRIPTION
# What & Why
Add an option to delete all buckets including objects inside them. Empty buckets will be deleted immediately. For non-empty buckets which potentially have millions of individual objects, it uses bucket lifecycle policy to delete all objects by the next day. And a user can run the script again after all the objects get deleted.

# QA
- [x] Run the script to make sure it deletes all the empty buckets
- [x] Wait one day for AWS to delete all objects in non-empty buckets
- [x] Verify all buckets are empty
- [x] Run the script again to delete all the buckets
- [x] Special buckets created by other AWS services (e.g. AWS Elastic Beanstalk) will be errored and skipped